### PR TITLE
[nicholas] Refactor cron job to use environment variables.

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,3 +1,3 @@
 # START CRON JOB
-0 * * * * /usr/local/bin/python3 /app/cfddns.py YourDomainHere APIKeyHere RecordTypeHere > /proc/1/fd/1 2>/proc/1/fd/2
+0 * * * * /bin/bash -c '/usr/local/bin/python3 /app/dyndns_client_cloudflare.py "$CLOUDFLARE_DOMAIN" "$CLOUDFLARE_API_KEY" "$CLOUDFLARE_RECORD_TYPE"' > /proc/1/fd/1 2>/proc/1/fd/2
 # END CRON JOB


### PR DESCRIPTION
Added a parent shell that interpolates variables before passing the python argument back to the shell. This resolves the unsafe practice of hard-coding sensitive information in the crontab file.